### PR TITLE
Add support for arbitrary image resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ MAXIM supports arbitrary image resolutions. However, the available TensorFlow mo
 
 But these models can be extended to support arbitrary resolution. Refer to [this notebook](https://colab.research.google.com/github/sayakpaul/maxim-tf/blob/main/notebooks/inference-dynamic-resize.ipynb) for more details. Specifically, for a given task and an image, a new version of the model is instantiated and the weights of the available model are copied into the new model instance. This is a time-consuming process and isn't very efficient. 
 
+#### Changes to achieve arbitrary image resolution on TF
+
+- Substitute einops calls for pure TF operations: Einops operations are not intended operate on data-dependent (unknown) dimensionality [https://github.com/data-apis/array-api/issues/494](https://github.com/data-apis/array-api/issues/494). Thus, it was necessary to re-write BlockImages and UnblockImages as full TF ops. For convenience, we separate BlockImages into TFBlockImages and TFBlockImagesByGrid. We also rewrote UnblockImages as TFUnblockImages. 
+- Make [dim_u](https://github.com/sayakpaul/maxim-tf/pull/24/files#diff-8b281bcfc137b53489e1b19b29735462d5deac19b8c2c2f82cf0383680908063R121) and [dim_v](https://github.com/sayakpaul/maxim-tf/pull/24/files#diff-8b281bcfc137b53489e1b19b29735462d5deac19b8c2c2f82cf0383680908063R130) parameters independent of the input image size. This can be done by computing dim_u and dim_v from the provided grid_size and/or block_size. 
+- Change resizing layers so as to receive a ratio independent of the image size. It was important to use the float ratios to compute the final image size, just then converting back to int, to avoid loss of information.
+ 
 ### Output mismatches
 
 The outputs of the TF and JAX models vary slightly. This is because of the differences in the implementation of different layers (resizing layer mainly). Even though the differences in the outputs of individual blocks of TF and JAX models are small, they add up, in the end, to be larger than one might expect. 

--- a/create_maxim_model.py
+++ b/create_maxim_model.py
@@ -4,7 +4,7 @@ from maxim import maxim
 from maxim.configs import MAXIM_CONFIGS
 
 
-def Model(variant=None, input_resolution=(256, 256), **kw) -> keras.Model:
+def Model(variant=None, input_resolution=(None, None), **kw) -> keras.Model:
     """Factory function to easily create a Model variant like "S".
 
     Args:

--- a/maxim/blocks/attentions.py
+++ b/maxim/blocks/attentions.py
@@ -134,7 +134,9 @@ def SAM(
 
         # Get attention maps for num_channels
         x2 = tf.nn.sigmoid(
-            Conv3x3(filters=num_channels, use_bias=use_bias, name=f"{name}_Conv_2")(image)
+            Conv3x3(filters=num_channels, use_bias=use_bias, name=f"{name}_Conv_2")(
+                image
+            )
         )
 
         # Get attended feature maps

--- a/maxim/blocks/block_gating.py
+++ b/maxim/blocks/block_gating.py
@@ -18,7 +18,9 @@ def BlockGatingUnit(use_bias: bool = True, name: str = "block_gating_unit"):
 
     def apply(x):
         u, v = tf.split(x, 2, axis=-1)
-        v = layers.LayerNormalization(epsilon=1e-06, name=f"{name}_intermediate_layernorm")(v)
+        v = layers.LayerNormalization(
+            epsilon=1e-06, name=f"{name}_intermediate_layernorm"
+        )(v)
         n = K.int_shape(x)[-2]  # get spatial dim
         v = SwapAxes()(v, -1, -2)
         v = layers.Dense(n, use_bias=use_bias, name=f"{name}_Dense_0")(v)

--- a/maxim/blocks/grid_gating.py
+++ b/maxim/blocks/grid_gating.py
@@ -18,7 +18,9 @@ def GridGatingUnit(use_bias: bool = True, name: str = "grid_gating_unit"):
 
     def apply(x):
         u, v = tf.split(x, 2, axis=-1)
-        v = layers.LayerNormalization(epsilon=1e-06, name=f"{name}_intermediate_layernorm")(v)
+        v = layers.LayerNormalization(
+            epsilon=1e-06, name=f"{name}_intermediate_layernorm"
+        )(v)
         n = K.int_shape(x)[-3]  # get spatial dim
         v = SwapAxes()(v, -1, -3)
         v = layers.Dense(n, use_bias=use_bias, name=f"{name}_Dense_0")(v)

--- a/maxim/blocks/grid_gating.py
+++ b/maxim/blocks/grid_gating.py
@@ -6,7 +6,7 @@ import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
-from ..layers import BlockImages, SwapAxes, UnblockImages
+from ..layers import SwapAxes, TFBlockImagesByGrid, TFUnblockImages
 
 
 def GridGatingUnit(use_bias: bool = True, name: str = "grid_gating_unit"):
@@ -18,9 +18,7 @@ def GridGatingUnit(use_bias: bool = True, name: str = "grid_gating_unit"):
 
     def apply(x):
         u, v = tf.split(x, 2, axis=-1)
-        v = layers.LayerNormalization(
-            epsilon=1e-06, name=f"{name}_intermediate_layernorm"
-        )(v)
+        v = layers.LayerNormalization(epsilon=1e-06, name=f"{name}_intermediate_layernorm")(v)
         n = K.int_shape(x)[-3]  # get spatial dim
         v = SwapAxes()(v, -1, -3)
         v = layers.Dense(n, use_bias=use_bias, name=f"{name}_Dense_0")(v)
@@ -47,9 +45,8 @@ def GridGmlpLayer(
             K.int_shape(x)[3],
         )
         gh, gw = grid_size
-        fh, fw = h // gh, w // gw
 
-        x = BlockImages()(x, patch_size=(fh, fw))
+        x, ph, pw = TFBlockImagesByGrid()(x, grid_size=(gh, gw))
         # gMLP1: Global (grid) mixing part, provides global grid communication.
         y = layers.LayerNormalization(epsilon=1e-06, name=f"{name}_LayerNorm")(x)
         y = layers.Dense(
@@ -66,7 +63,7 @@ def GridGmlpLayer(
         )(y)
         y = layers.Dropout(dropout_rate)(y)
         x = x + y
-        x = UnblockImages()(x, grid_size=(gh, gw), patch_size=(fh, fw))
+        x = TFUnblockImages()(x, grid_size=(gh, gw), patch_size=(ph, pw))
         return x
 
     return apply

--- a/maxim/blocks/misc_gating.py
+++ b/maxim/blocks/misc_gating.py
@@ -8,18 +8,14 @@ import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
-from ..layers import BlockImages, SwapAxes, UnblockImages
+from ..layers import SwapAxes, TFBlockImages, TFBlockImagesByGrid, TFUnblockImages
 from .block_gating import BlockGmlpLayer
 from .grid_gating import GridGmlpLayer
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 Conv3x3 = functools.partial(layers.Conv2D, kernel_size=(3, 3), padding="same")
-ConvT_up = functools.partial(
-    layers.Conv2DTranspose, kernel_size=(2, 2), strides=(2, 2), padding="same"
-)
-Conv_down = functools.partial(
-    layers.Conv2D, kernel_size=(4, 4), strides=(2, 2), padding="same"
-)
+ConvT_up = functools.partial(layers.Conv2DTranspose, kernel_size=(2, 2), strides=(2, 2), padding="same")
+Conv_down = functools.partial(layers.Conv2D, kernel_size=(4, 4), strides=(2, 2), padding="same")
 
 
 def ResidualSplitHeadMultiAxisGmlpLayer(
@@ -116,24 +112,22 @@ def GetSpatialGatingWeights(
         u, v = tf.split(x, 2, axis=-1)
 
         # Get grid MLP weights
-        gh, gw = grid_size
-        fh, fw = h // gh, w // gw
-        u = BlockImages()(u, patch_size=(fh, fw))
-        dim_u = K.int_shape(u)[-3]
+        ghu, gwu = grid_size
+        u, phu, pwu = TFBlockImagesByGrid()(u, grid_size=(ghu, gwu))
+        dim_u = ghu * gwu
         u = SwapAxes()(u, -1, -3)
         u = layers.Dense(dim_u, use_bias=use_bias, name=f"{name}_Dense_0")(u)
         u = SwapAxes()(u, -1, -3)
-        u = UnblockImages()(u, grid_size=(gh, gw), patch_size=(fh, fw))
+        u = TFUnblockImages()(u, grid_size=(ghu, gwu), patch_size=(phu, pwu))
 
         # Get Block MLP weights
-        fh, fw = block_size
-        gh, gw = h // fh, w // fw
-        v = BlockImages()(v, patch_size=(fh, fw))
-        dim_v = K.int_shape(v)[-2]
+        fhv, fwv = block_size
+        v, ghv, gwv = TFBlockImages()(v, patch_size=(fhv, fwv))
+        dim_v = fhv * fwv
         v = SwapAxes()(v, -1, -2)
         v = layers.Dense(dim_v, use_bias=use_bias, name=f"{name}_Dense_1")(v)
         v = SwapAxes()(v, -1, -2)
-        v = UnblockImages()(v, grid_size=(gh, gw), patch_size=(fh, fw))
+        v = TFUnblockImages()(v, patch_size=(fhv, fwv), grid_size=(ghv, gwv))
 
         x = tf.concat([u, v], axis=-1)
         x = layers.Dense(num_channels, use_bias=use_bias, name=f"{name}_out_project")(x)
@@ -159,9 +153,7 @@ def CrossGatingBlock(
     def apply(x, y):
         # Upscale Y signal, y is the gating signal.
         if upsample_y:
-            y = ConvT_up(
-                filters=features, use_bias=use_bias, name=f"{name}_ConvTranspose_0"
-            )(y)
+            y = ConvT_up(filters=features, use_bias=use_bias, name=f"{name}_ConvTranspose_0")(y)
 
         x = Conv1x1(filters=features, use_bias=use_bias, name=f"{name}_Conv_0")(x)
         n, h, w, num_channels = (

--- a/maxim/blocks/others.py
+++ b/maxim/blocks/others.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
-from ..layers import ResizingUp
+from ..layers import Resizing, ResizingUp
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 
@@ -32,13 +32,15 @@ def MlpBlock(
     return apply
 
 
-def UpSampleRatio(num_channels: int, ratio: float, use_bias: bool = True, name: str = "upsample"):
+def UpSampleRatio(
+    num_channels: int, ratio: float, use_bias: bool = True, name: str = "upsample"
+):
     """Upsample features given a ratio > 0."""
 
     def apply(x):
         # Following `jax.image.resize()`
-        x = ResizingUp(
-            ratio=ratio,
+        x = Resizing(
+            ratio=1 / ratio,
             method="bilinear",
             antialias=True,
             name=f"{name}_resizing_{K.get_uid('Resizing')}",

--- a/maxim/blocks/others.py
+++ b/maxim/blocks/others.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
-from ..layers import Resizing
+from ..layers import ResizingUp
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 
@@ -32,23 +32,13 @@ def MlpBlock(
     return apply
 
 
-def UpSampleRatio(
-    num_channels: int, ratio: float, use_bias: bool = True, name: str = "upsample"
-):
+def UpSampleRatio(num_channels: int, ratio: float, use_bias: bool = True, name: str = "upsample"):
     """Upsample features given a ratio > 0."""
 
     def apply(x):
-        n, h, w, c = (
-            K.int_shape(x)[0],
-            K.int_shape(x)[1],
-            K.int_shape(x)[2],
-            K.int_shape(x)[3],
-        )
-
         # Following `jax.image.resize()`
-        x = Resizing(
-            height=int(h * ratio),
-            width=int(w * ratio),
+        x = ResizingUp(
+            ratio=ratio,
             method="bilinear",
             antialias=True,
             name=f"{name}_resizing_{K.get_uid('Resizing')}",

--- a/maxim/blocks/others.py
+++ b/maxim/blocks/others.py
@@ -8,7 +8,7 @@ import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
-from ..layers import Resizing, ResizingUp
+from ..layers import Resizing
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 

--- a/maxim/layers.py
+++ b/maxim/layers.py
@@ -1,65 +1,89 @@
 """
 Layers based on https://github.com/google-research/maxim/blob/main/maxim/models/maxim.py
+and reworked to cope with variable image dimensions
 """
 
-import einops
 import tensorflow as tf
 from tensorflow.experimental import numpy as tnp
-from tensorflow.keras import backend as K
 from tensorflow.keras import layers
 
 
 @tf.keras.utils.register_keras_serializable("maxim")
-class BlockImages(layers.Layer):
+class TFBlockImages(layers.Layer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def call(self, x, patch_size):
-        bs, h, w, num_channels = (
-            K.int_shape(x)[0],
-            K.int_shape(x)[1],
-            K.int_shape(x)[2],
-            K.int_shape(x)[3],
-        )
-
-        grid_height, grid_width = h // patch_size[0], w // patch_size[1]
-
-        x = einops.rearrange(
-            x,
-            "n (gh fh) (gw fw) c -> n (gh gw) (fh fw) c",
-            gh=grid_height,
-            gw=grid_width,
-            fh=patch_size[0],
-            fw=patch_size[1],
-        )
-
-        return x
+    def call(self, image, patch_size):
+        bs, h, w, num_channels = (tf.shape(image)[0], tf.shape(image)[1], tf.shape(image)[2], tf.shape(image)[3])
+        ph, pw = patch_size
+        gh = h // ph
+        gw = w // pw
+        pad = [[0, 0], [0, 0]]
+        patches = tf.space_to_batch_nd(image, [ph, pw], pad)
+        patches = tf.split(patches, ph * pw, axis=0)
+        patches = tf.stack(patches, 3)  # (bs, h/p, h/p, p*p, 3)
+        patches_dim = tf.shape(patches)
+        patches = tf.reshape(patches, [patches_dim[0], patches_dim[1], patches_dim[2], -1])
+        patches = tf.reshape(patches, (patches_dim[0], patches_dim[1] * patches_dim[2], ph * pw, num_channels))
+        return [patches, gh, gw]
 
     def get_config(self):
-        config = super().get_config().copy()
-        return config
+        return super().get_config()
 
 
 @tf.keras.utils.register_keras_serializable("maxim")
-class UnblockImages(layers.Layer):
+class TFBlockImagesByGrid(layers.Layer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def call(self, x, grid_size, patch_size):
-        x = einops.rearrange(
-            x,
-            "n (gh gw) (fh fw) c -> n (gh fh) (gw fw) c",
-            gh=grid_size[0],
-            gw=grid_size[1],
-            fh=patch_size[0],
-            fw=patch_size[1],
-        )
+    def call(self, image, grid_size):
+        bs, h, w, num_channels = (tf.shape(image)[0], tf.shape(image)[1], tf.shape(image)[2], tf.shape(image)[3])
+        gh, gw = grid_size
+        ph = h // gh
+        pw = w // gw
+        pad = [[0, 0], [0, 0]]
 
-        return x
+        def block_single_image(img):
+            pat = tf.expand_dims(img, 0)  # batch = 1
+            pat = tf.space_to_batch_nd(pat, [ph, pw], pad)  # p*p*bs, g, g, c
+            pat = tf.expand_dims(pat, 3)  # pxpxbs, g, g, 1, c
+            pat = tf.transpose(pat, perm=[3, 1, 2, 0, 4])  # 1, g, g, pxp, c
+            pat = tf.reshape(pat, [gh, gw, ph * pw, num_channels])
+            return pat
+
+        patches = image
+        patches = tf.map_fn(fn=lambda x: block_single_image(x), elems=patches)
+        patches_dim = tf.shape(patches)
+        patches = tf.reshape(patches, [patches_dim[0], patches_dim[1], patches_dim[2], -1])
+        patches = tf.reshape(patches, (patches_dim[0], patches_dim[1] * patches_dim[2], ph * pw, num_channels))
+        return [patches, ph, pw]
 
     def get_config(self):
-        config = super().get_config().copy()
-        return config
+        return super().get_config()
+
+
+@tf.keras.utils.register_keras_serializable("maxim")
+class TFUnblockImages(layers.Layer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def call(self, x, patch_size, grid_size):
+        bs, grid_sqrt, patch_sqrt, num_channels = (tf.shape(x)[0], tf.shape(x)[1], tf.shape(x)[2], tf.shape(x)[3])
+        ph, pw = patch_size
+        gh, gw = grid_size
+
+        pad = [[0, 0], [0, 0]]
+
+        y = tf.reshape(x, (bs, gh, gw, -1, num_channels))  # (bs, gh, gw, ph*pw, 3)
+        y = tf.expand_dims(y, 0)
+        y = tf.transpose(y, perm=[4, 1, 2, 3, 0, 5])
+        y = tf.reshape(y, [bs * ph * pw, gh, gw, num_channels])
+        y = tf.batch_to_space(y, [ph, pw], pad)
+
+        return y
+
+    def get_config(self):
+        return super().get_config()
 
 
 @tf.keras.utils.register_keras_serializable("maxim")
@@ -76,28 +100,60 @@ class SwapAxes(layers.Layer):
 
 
 @tf.keras.utils.register_keras_serializable("maxim")
-class Resizing(layers.Layer):
-    def __init__(self, height, width, antialias=True, method="bilinear", **kwargs):
+class ResizingDown(tf.keras.layers.Layer):
+    def __init__(self, ratio: float, method="bilinear", antialias=True, **kwargs):
         super().__init__(**kwargs)
-        self.height = height
-        self.width = width
-        self.antialias = antialias
+        self.ratio = ratio
         self.method = method
+        self.antialias = antialias
 
-    def call(self, x):
-        return tf.image.resize(
-            x,
-            size=(self.height, self.width),
-            antialias=self.antialias,
+    def __call__(self, img):
+        n, h, w, c = (tf.shape(img)[0], tf.shape(img)[1], tf.shape(img)[2], tf.shape(img)[3])
+        x = tf.image.resize(
+            img,
+            (h // self.ratio, w // self.ratio),
             method=self.method,
+            antialias=self.antialias,
         )
+        return x
 
     def get_config(self):
         config = super().get_config().copy()
         config.update(
             {
-                "height": self.height,
-                "width": self.width,
+                "ratio": self.ratio,
+                "antialias": self.antialias,
+                "method": self.method,
+            }
+        )
+        return config
+
+
+@tf.keras.utils.register_keras_serializable("maxim")
+class ResizingUp(tf.keras.layers.Layer):
+    def __init__(self, ratio: float, method="bilinear", antialias=True, **kwargs):
+        super().__init__(**kwargs)
+        self.ratio = tf.constant(ratio, dtype=tf.float32)
+        self.method = method
+        self.antialias = antialias
+
+    def __call__(self, img):
+        shape = tf.shape(img)
+        new_sh = self.ratio * tf.cast(shape[1:3], tf.float32)
+
+        x = tf.image.resize(
+            img,
+            size=tf.cast(new_sh, tf.int32),
+            method=self.method,
+            antialias=self.antialias,
+        )
+        return x
+
+    def get_config(self):
+        config = super().get_config().copy()
+        config.update(
+            {
+                "ratio": self.ratio,
                 "antialias": self.antialias,
                 "method": self.method,
             }

--- a/maxim/maxim.py
+++ b/maxim/maxim.py
@@ -13,16 +13,12 @@ from .blocks.bottleneck import BottleneckBlock
 from .blocks.misc_gating import CrossGatingBlock
 from .blocks.others import UpSampleRatio
 from .blocks.unet import UNetDecoderBlock, UNetEncoderBlock
-from .layers import Resizing
+from .layers import ResizingDown
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 Conv3x3 = functools.partial(layers.Conv2D, kernel_size=(3, 3), padding="same")
-ConvT_up = functools.partial(
-    layers.Conv2DTranspose, kernel_size=(2, 2), strides=(2, 2), padding="same"
-)
-Conv_down = functools.partial(
-    layers.Conv2D, kernel_size=(4, 4), strides=(2, 2), padding="same"
-)
+ConvT_up = functools.partial(layers.Conv2DTranspose, kernel_size=(2, 2), strides=(2, 2), padding="same")
+Conv_down = functools.partial(layers.Conv2D, kernel_size=(4, 4), strides=(2, 2), padding="same")
 
 
 def MAXIM(
@@ -102,9 +98,8 @@ def MAXIM(
 
         # Get multi-scale input images
         for i in range(1, num_supervision_scales):
-            resizing_layer = Resizing(
-                height=h // (2 ** i),
-                width=w // (2 ** i),
+            resizing_layer = ResizingDown(
+                ratio=(2**i),
                 method="nearest",
                 antialias=True,  # Following `jax.image.resize()`.
                 name=f"initial_resizing_{K.get_uid('Resizing')}",
@@ -122,7 +117,7 @@ def MAXIM(
             x_scales = []
             for i in range(num_supervision_scales):
                 x_scale = Conv3x3(
-                    filters=(2 ** i) * features,
+                    filters=(2**i) * features,
                     use_bias=use_bias,
                     name=f"stage_{idx_stage}_input_conv_{i}",
                 )(shortcuts[i])
@@ -131,12 +126,10 @@ def MAXIM(
                 if idx_stage > 0:
                     # use larger blocksize at high-res stages
                     if use_cross_gating:
-                        block_size = (
-                            block_size_hr if i < high_res_stages else block_size_lr
-                        )
+                        block_size = block_size_hr if i < high_res_stages else block_size_lr
                         grid_size = grid_size_hr if i < high_res_stages else block_size_lr
                         x_scale, _ = CrossGatingBlock(
-                            features=(2 ** i) * features,
+                            features=(2**i) * features,
                             block_size=block_size,
                             grid_size=grid_size,
                             dropout_rate=dropout_rate,
@@ -147,7 +140,7 @@ def MAXIM(
                         )(x_scale, sam_features.pop())
                     else:
                         x_scale = Conv1x1(
-                            filters=(2 ** i) * features,
+                            filters=(2**i) * features,
                             use_bias=use_bias,
                             name=f"stage_{idx_stage}_input_catconv_{i}",
                         )(tf.concat([x_scale, sam_features.pop()], axis=-1))
@@ -172,7 +165,7 @@ def MAXIM(
                 dec_prev = decs_prev.pop() if idx_stage > 0 else None
 
                 x, bridge = UNetEncoderBlock(
-                    num_channels=(2 ** i) * features,
+                    num_channels=(2**i) * features,
                     num_groups=num_groups,
                     downsample=True,
                     lrelu_slope=lrelu_slope,
@@ -221,7 +214,7 @@ def MAXIM(
                 signal = tf.concat(
                     [
                         UpSampleRatio(
-                            num_channels=(2 ** i) * features,
+                            num_channels=(2**i) * features,
                             ratio=2 ** (j - i),
                             use_bias=use_bias,
                             name=f"UpSampleRatio_{K.get_uid('UpSampleRatio')}",
@@ -234,7 +227,7 @@ def MAXIM(
                 # Use cross-gating to cross modulate features
                 if use_cross_gating:
                     skips, global_feature = CrossGatingBlock(
-                        features=(2 ** i) * features,
+                        features=(2**i) * features,
                         block_size=block_size,
                         grid_size=grid_size,
                         input_proj_factor=input_proj_factor,
@@ -244,12 +237,8 @@ def MAXIM(
                         name=f"stage_{idx_stage}_cross_gating_block_{i}",
                     )(signal, global_feature)
                 else:
-                    skips = Conv1x1(
-                        filters=(2 ** i) * features, use_bias=use_bias, name="Conv_0"
-                    )(signal)
-                    skips = Conv3x3(
-                        filters=(2 ** i) * features, use_bias=use_bias, name="Conv_1"
-                    )(skips)
+                    skips = Conv1x1(filters=(2**i) * features, use_bias=use_bias, name="Conv_0")(signal)
+                    skips = Conv3x3(filters=(2**i) * features, use_bias=use_bias, name="Conv_1")(skips)
 
                 skip_features.append(skips)
 
@@ -264,7 +253,7 @@ def MAXIM(
                 signal = tf.concat(
                     [
                         UpSampleRatio(
-                            num_channels=(2 ** i) * features,
+                            num_channels=(2**i) * features,
                             ratio=2 ** (depth - j - 1 - i),
                             use_bias=use_bias,
                             name=f"UpSampleRatio_{K.get_uid('UpSampleRatio')}",
@@ -276,7 +265,7 @@ def MAXIM(
 
                 # Decoder block
                 x = UNetDecoderBlock(
-                    num_channels=(2 ** i) * features,
+                    num_channels=(2**i) * features,
                     num_groups=num_groups,
                     lrelu_slope=lrelu_slope,
                     block_size=block_size,
@@ -298,7 +287,7 @@ def MAXIM(
                 if i < num_supervision_scales:
                     if idx_stage < num_stages - 1:  # not last stage, apply SAM
                         sam, output = SAM(
-                            num_channels=(2 ** i) * features,
+                            num_channels=(2**i) * features,
                             output_channels=num_outputs,
                             use_bias=use_bias,
                             name=f"stage_{idx_stage}_supervised_attention_module_{i}",

--- a/maxim/maxim.py
+++ b/maxim/maxim.py
@@ -13,7 +13,7 @@ from .blocks.bottleneck import BottleneckBlock
 from .blocks.misc_gating import CrossGatingBlock
 from .blocks.others import UpSampleRatio
 from .blocks.unet import UNetDecoderBlock, UNetEncoderBlock
-from .layers import Resizing, ResizingDown
+from .layers import Resizing
 
 Conv1x1 = functools.partial(layers.Conv2D, kernel_size=(1, 1), padding="same")
 Conv3x3 = functools.partial(layers.Conv2D, kernel_size=(3, 3), padding="same")

--- a/maxim/tests/conftest.py
+++ b/maxim/tests/conftest.py
@@ -39,7 +39,8 @@ def random_image_multiple_of_64(request, fix_random, window_size):
     return tf.random.uniform(shape=(1, h_img, w_img, 3), dtype=tf.float32)
 
 
-############################################
+##########################################################################
+########################## Fixtures for model test #######################
 
 
 def Model(variant=None, input_resolution=(None, None), **kw) -> keras.Model:

--- a/maxim/tests/conftest.py
+++ b/maxim/tests/conftest.py
@@ -1,0 +1,84 @@
+import gc
+import random
+
+import pytest
+import tensorflow as tf
+from maxim import maxim
+from maxim.configs import MAXIM_CONFIGS
+from tensorflow import keras
+
+
+@pytest.fixture()
+def fix_random():
+    tf.random.set_seed(0)
+    random.seed(0)
+
+
+@pytest.fixture(params=[(16, 12), (12, 16), (16, 16)])
+def window_size(request):
+    return request.param
+
+
+@pytest.fixture(params=[20, 30, 40])
+def random_image(request, fix_random, window_size):
+    h, w = window_size
+    n_windows = request.param
+
+    h_img = h * n_windows
+    w_img = w * n_windows
+
+    return tf.random.uniform(shape=(5, h_img, w_img, 3), dtype=tf.float32)
+
+
+@pytest.fixture(params=[(10, 13), (14, 15), (20, 20)])
+def random_image_multiple_of_64(request, fix_random, window_size):
+    h, w = request.param
+    h_img = h * 64
+    w_img = w * 64
+
+    return tf.random.uniform(shape=(1, h_img, w_img, 3), dtype=tf.float32)
+
+
+############################################
+
+
+def Model(variant=None, input_resolution=(None, None), **kw) -> keras.Model:
+    """Factory function to easily create a Model variant like "S".
+
+    Args:
+      variant: UNet model variants. Options: 'S-1' | 'S-2' | 'S-3'
+          | 'M-1' | 'M-2' | 'M-3'
+      input_resolution: Size of the input images.
+      **kw: Other UNet config dicts.
+
+    Returns:
+      The MAXIM model.
+    """
+
+    if variant is not None:
+        config = MAXIM_CONFIGS[variant]
+        for k, v in config.items():
+            kw.setdefault(k, v)
+
+    if "variant" in kw:
+        _ = kw.pop("variant")
+    if "input_resolution" in kw:
+        _ = kw.pop("input_resolution")
+    model_name = kw.pop("name")
+
+    maxim_model = maxim.MAXIM(**kw)
+
+    inputs = keras.Input((*input_resolution, 3))
+    outputs = maxim_model(inputs)
+    final_model = keras.Model(inputs, outputs, name=f"{model_name}_model")
+
+    return final_model
+
+
+# Scope = session means it should only be instantiated once per test session.
+@pytest.fixture(scope="session", params=["S-2"])
+def none_model(request):
+    model = Model(variant=request.param, input_resolution=(None, None))
+    yield model
+    del model
+    gc.collect()

--- a/maxim/tests/test_block_operations.py
+++ b/maxim/tests/test_block_operations.py
@@ -1,0 +1,129 @@
+import random
+
+import einops
+import numpy as np
+import tensorflow as tf
+from maxim.layers import TFBlockImages, TFBlockImagesByGrid, TFUnblockImages
+from tensorflow.keras import backend as K
+from tensorflow.keras import layers
+
+LOW_THRESHOLD = 1e-7
+
+
+@tf.keras.utils.register_keras_serializable("maxim")
+class BlockImages(layers.Layer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def call(self, x, patch_size):
+        bs, h, w, num_channels = (
+            K.int_shape(x)[0],
+            K.int_shape(x)[1],
+            K.int_shape(x)[2],
+            K.int_shape(x)[3],
+        )
+
+        grid_height, grid_width = h // patch_size[0], w // patch_size[1]
+
+        x = einops.rearrange(
+            x,
+            "n (gh fh) (gw fw) c -> n (gh gw) (fh fw) c",
+            gh=grid_height,
+            gw=grid_width,
+            fh=patch_size[0],
+            fw=patch_size[1],
+        )
+
+        return x
+
+    def get_config(self):
+        config = super().get_config().copy()
+        return config
+
+
+@tf.keras.utils.register_keras_serializable("maxim")
+class UnblockImages(layers.Layer):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def call(self, x, grid_size, patch_size):
+        x = einops.rearrange(
+            x,
+            "n (gh gw) (fh fw) c -> n (gh fh) (gw fw) c",
+            gh=grid_size[0],
+            gw=grid_size[1],
+            fh=patch_size[0],
+            fw=patch_size[1],
+        )
+
+        return x
+
+    def get_config(self):
+        config = super().get_config().copy()
+        return config
+
+
+def test_patch_block_equivalence(random_image, window_size):
+    patch_size = window_size
+    patched_image_original = BlockImages()(random_image, patch_size=patch_size)
+    patched_image_tf, _, _ = TFBlockImages()(random_image, patch_size=patch_size)
+    difference = np.sum((patched_image_original.numpy() - patched_image_tf.numpy()) ** 2)
+    assert difference < LOW_THRESHOLD
+
+
+def test_grid_block_equivalence(random_image, window_size):
+    grid_size = window_size
+    gh, gw = grid_size
+    height, width = random_image.shape[1], random_image.shape[2]
+    patch_size = (height // gh, width // gw)
+    patched_image_original = BlockImages()(random_image, patch_size=patch_size)
+    patched_image_tf, _, _ = TFBlockImagesByGrid()(random_image, grid_size=grid_size)
+    difference = np.sum((patched_image_original.numpy() - patched_image_tf.numpy()) ** 2)
+    assert difference < LOW_THRESHOLD
+
+
+def test_reconstruction_by_grid(random_image, window_size):
+    grid_size = window_size
+    height, width = random_image.shape[1], random_image.shape[2]
+    p_h, p_w = height // grid_size[0], width // grid_size[1]
+
+    # Block and Unblock with einops layers
+    patched_image_original = BlockImages()(random_image, patch_size=(p_h, p_w))
+    reconstructed_original = UnblockImages()(
+        patched_image_original,
+        grid_size=grid_size,
+        patch_size=(p_h, p_w),
+    )
+
+    # Block and Unblock with TF layers
+    patched_image_tf, ph, pw = TFBlockImagesByGrid()(random_image, grid_size=grid_size)
+    reconstructed_image_tf = TFUnblockImages()(patched_image_tf, grid_size=grid_size, patch_size=(ph, pw))
+
+    # Compare implementation diff and reconstruction diff
+    difference_between_implementations = np.sum((reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    assert difference_between_implementations < LOW_THRESHOLD
+    difference_between_reconstruction = np.sum((random_image.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    assert difference_between_reconstruction < LOW_THRESHOLD
+
+
+def test_reconstruction(random_image, window_size):
+    patch_size = window_size
+    height, width = random_image.shape[1], random_image.shape[2]
+
+    # Block and Unblock with einops layers
+    patched_image_original = BlockImages()(random_image, patch_size=patch_size)
+    reconstructed_original = UnblockImages()(
+        patched_image_original,
+        grid_size=(height // patch_size[0], width // patch_size[1]),
+        patch_size=patch_size,
+    )
+
+    # Block and Unblock with TF layers
+    patched_image_tf, gh, gw = TFBlockImages()(random_image, patch_size=patch_size)
+    reconstructed_image_tf = TFUnblockImages()(patched_image_tf, patch_size=patch_size, grid_size=(gh, gw))
+
+    # Compare implementation diff and reconstruction diff
+    difference_between_implementations = np.sum((reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    assert difference_between_implementations < LOW_THRESHOLD
+    difference_between_reconstruction = np.sum((random_image.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    assert difference_between_reconstruction < LOW_THRESHOLD

--- a/maxim/tests/test_block_operations.py
+++ b/maxim/tests/test_block_operations.py
@@ -67,7 +67,9 @@ def test_patch_block_equivalence(random_image, window_size):
     patch_size = window_size
     patched_image_original = BlockImages()(random_image, patch_size=patch_size)
     patched_image_tf, _, _ = TFBlockImages()(random_image, patch_size=patch_size)
-    difference = np.sum((patched_image_original.numpy() - patched_image_tf.numpy()) ** 2)
+    difference = np.sum(
+        (patched_image_original.numpy() - patched_image_tf.numpy()) ** 2
+    )
     assert difference < LOW_THRESHOLD
 
 
@@ -78,7 +80,9 @@ def test_grid_block_equivalence(random_image, window_size):
     patch_size = (height // gh, width // gw)
     patched_image_original = BlockImages()(random_image, patch_size=patch_size)
     patched_image_tf, _, _ = TFBlockImagesByGrid()(random_image, grid_size=grid_size)
-    difference = np.sum((patched_image_original.numpy() - patched_image_tf.numpy()) ** 2)
+    difference = np.sum(
+        (patched_image_original.numpy() - patched_image_tf.numpy()) ** 2
+    )
     assert difference < LOW_THRESHOLD
 
 
@@ -97,12 +101,18 @@ def test_reconstruction_by_grid(random_image, window_size):
 
     # Block and Unblock with TF layers
     patched_image_tf, ph, pw = TFBlockImagesByGrid()(random_image, grid_size=grid_size)
-    reconstructed_image_tf = TFUnblockImages()(patched_image_tf, grid_size=grid_size, patch_size=(ph, pw))
+    reconstructed_image_tf = TFUnblockImages()(
+        patched_image_tf, grid_size=grid_size, patch_size=(ph, pw)
+    )
 
     # Compare implementation diff and reconstruction diff
-    difference_between_implementations = np.sum((reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    difference_between_implementations = np.sum(
+        (reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2
+    )
     assert difference_between_implementations < LOW_THRESHOLD
-    difference_between_reconstruction = np.sum((random_image.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    difference_between_reconstruction = np.sum(
+        (random_image.numpy() - reconstructed_image_tf.numpy()) ** 2
+    )
     assert difference_between_reconstruction < LOW_THRESHOLD
 
 
@@ -120,10 +130,16 @@ def test_reconstruction(random_image, window_size):
 
     # Block and Unblock with TF layers
     patched_image_tf, gh, gw = TFBlockImages()(random_image, patch_size=patch_size)
-    reconstructed_image_tf = TFUnblockImages()(patched_image_tf, patch_size=patch_size, grid_size=(gh, gw))
+    reconstructed_image_tf = TFUnblockImages()(
+        patched_image_tf, patch_size=patch_size, grid_size=(gh, gw)
+    )
 
     # Compare implementation diff and reconstruction diff
-    difference_between_implementations = np.sum((reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    difference_between_implementations = np.sum(
+        (reconstructed_original.numpy() - reconstructed_image_tf.numpy()) ** 2
+    )
     assert difference_between_implementations < LOW_THRESHOLD
-    difference_between_reconstruction = np.sum((random_image.numpy() - reconstructed_image_tf.numpy()) ** 2)
+    difference_between_reconstruction = np.sum(
+        (random_image.numpy() - reconstructed_image_tf.numpy()) ** 2
+    )
     assert difference_between_reconstruction < LOW_THRESHOLD

--- a/maxim/tests/test_maxim_variable_img_length.py
+++ b/maxim/tests/test_maxim_variable_img_length.py
@@ -1,0 +1,4 @@
+def test_maxim_variable_length(none_model, random_image_multiple_of_64):
+    # this line will run several times with random images of different size
+    # The none_model is instantiated only once, since the fixture scope is session.
+    out = none_model(random_image_multiple_of_64)


### PR DESCRIPTION
Hi,

This PR adds support for arbitrary image resolution. Here's what I did to make it possible:

- Rework Image Resizing layers as pointed out [here](https://github.com/sayakpaul/maxim-tf/pull/20)
- Rewrite Block and Unblock layers to use pure tensorflow: this was necessary because einops does not accept tensors as pattern arguments, which is necessary in some layers of maxim.
- Realize that [dim_u](https://github.com/sayakpaul/maxim-tf/blob/feat/dynamic-shape/maxim/blocks/misc_gating.py#L124) and dim_v could be substituted for the window_size squared.
- Apply changes to the model itself. (edit: by that I meant substitute the layers for the TF ones, and plug in the necessary arguments for them to work)

I hope this helps, please let me know what you think.

you can test it quickly by: `pytest -v maxim/tests/`

Best,
Levi.